### PR TITLE
feat(landing): improve RWD and prevent horizontal overflow on small screens

### DIFF
--- a/app/components/Dashboard/CalendarCard.vue
+++ b/app/components/Dashboard/CalendarCard.vue
@@ -24,10 +24,7 @@ const t = useI18N()
   >
     <div class="p-2 flex flex-col">
       <div
-        :style="{
-          flexWrap: 'nowrap',
-        }"
-        class="flex flex-wrap gap-2 children:flex-grow children:sm:flex-basis-[200px]"
+        class="flex flex-wrap gap-2 sm:flex-nowrap children:flex-grow children:sm:flex-basis-[200px] min-w-0"
       >
         <DashboardDataBody
           :title="t.dashboard.overview.statistic.timeTotal"

--- a/app/components/Dashboard/CalendarCard.vue
+++ b/app/components/Dashboard/CalendarCard.vue
@@ -24,7 +24,7 @@ const t = useI18N()
   >
     <div class="p-2 flex flex-col">
       <div
-        class="flex flex-wrap gap-2 sm:flex-nowrap children:flex-grow children:sm:flex-basis-[200px] min-w-0"
+        class="flex flex-wrap gap-2 min-w-0 children:flex-grow sm:flex-nowrap children:sm:flex-basis-[200px]"
       >
         <DashboardDataBody
           :title="t.dashboard.overview.statistic.timeTotal"

--- a/app/components/Landing/PriceTab.vue
+++ b/app/components/Landing/PriceTab.vue
@@ -6,7 +6,7 @@ const t = useI18N()
 </script>
 
 <template>
-  <div class="grid grid-cols-1 gap-2 w-full max-w-[min(100%,42rem)] sm:grid-cols-3 !children:px-3 sm:!children:px-4 !children:py-1 !children:text-center !children:rounded-xl !children:gap-2 !children:min-w-0 !children:w-full !children:cursor-pointer !children:duration-100 !children:ease-in-out">
+  <div class="gap-2 grid grid-cols-1 max-w-[min(100%,42rem)] w-full sm:grid-cols-3 !children:px-3 !children:py-1 !children:text-center !children:rounded-xl !children:gap-2 !children:min-w-0 !children:w-full !children:cursor-pointer !children:duration-100 !children:ease-in-out sm:!children:px-4">
     <Btn
       :variant="variant === 'monthly' ? 'filled' : 'default'"
       class="!h-14"

--- a/app/components/Landing/PriceTab.vue
+++ b/app/components/Landing/PriceTab.vue
@@ -6,7 +6,7 @@ const t = useI18N()
 </script>
 
 <template>
-  <div class="flex gap-2 !children:px-4 !children:py-1 !children:text-center !children:rounded-xl !children:gap-2 !children:min-w-24 !children:cursor-pointer !children:duration-100 !children:ease-in-out">
+  <div class="grid grid-cols-1 gap-2 w-full max-w-[min(100%,42rem)] sm:grid-cols-3 !children:px-3 sm:!children:px-4 !children:py-1 !children:text-center !children:rounded-xl !children:gap-2 !children:min-w-0 !children:w-full !children:cursor-pointer !children:duration-100 !children:ease-in-out">
     <Btn
       :variant="variant === 'monthly' ? 'filled' : 'default'"
       class="!h-14"

--- a/app/components/Landing/SumHours.vue
+++ b/app/components/Landing/SumHours.vue
@@ -65,7 +65,7 @@ const t = useI18N()
 </script>
 
 <template>
-  <div class="stats-card px-8 py-12 flex flex-col gap-4 shadow-sm items-center relative overflow-hidden backdrop-blur-sm">
+  <div class="stats-card px-4 py-10 sm:px-8 sm:py-12 flex flex-col gap-4 shadow-sm items-center relative overflow-hidden backdrop-blur-sm">
     <div class="opacity-20 inset-0 absolute">
       <div class="floating-circles">
         <div class="floating-circle" />
@@ -74,24 +74,27 @@ const t = useI18N()
       </div>
     </div>
 
-    <div class="flex flex-col gap-4 items-center relative z-10">
-      <span class="stats-subtitle text-sm tracking-wide font-medium inline-block">
+    <div class="flex flex-col gap-4 items-center relative z-10 w-full min-w-0">
+      <span class="stats-subtitle text-xs sm:text-sm tracking-wide font-medium inline-block text-center px-2">
         {{ t.landing.alreadyStatistical }} ({{ t.landing.minutes }})
       </span>
 
-      <div v-if="status === 'success'" class="text-6xl flex gap-3 items-end">
+      <div
+        v-if="status === 'success'"
+        class="stats-number-wrap flex items-end justify-center w-full min-w-0"
+      >
         <span
           key="b"
-          class="stats-number animate-pulse-glow font-bold font-mono"
+          class="stats-number animate-pulse-glow font-bold font-mono leading-none max-w-full"
         >
           {{ fomater.format(minutes) }}
         </span>
       </div>
 
-      <div v-else class="text-6xl flex gap-3 items-end">
+      <div v-else class="flex items-end justify-center w-full min-w-0">
         <div
           key="a"
-          class="shimmer font-bold font-mono rounded-lg h-15 min-w-84 animate-pulse"
+          class="shimmer font-bold font-mono rounded-lg h-12 sm:h-15 w-[min(21rem,80vw)] animate-pulse"
         />
       </div>
 
@@ -133,10 +136,18 @@ const t = useI18N()
 }
 
 .stats-number {
+  display: block;
+  font-size: clamp(2rem, 9vw, 3.75rem);
+  line-height: 1;
+  white-space: nowrap;
   background: linear-gradient(135deg, #0284c7 0%, #0369a1 100%);
   background-clip: text;
   -webkit-background-clip: text;
   color: transparent;
+}
+
+.stats-number-wrap {
+  overflow: hidden;
 }
 
 [data-scheme="dark"] .stats-number {

--- a/app/components/Landing/SumHours.vue
+++ b/app/components/Landing/SumHours.vue
@@ -65,7 +65,7 @@ const t = useI18N()
 </script>
 
 <template>
-  <div class="stats-card px-4 py-10 sm:px-8 sm:py-12 flex flex-col gap-4 shadow-sm items-center relative overflow-hidden backdrop-blur-sm">
+  <div class="stats-card px-4 py-10 flex flex-col gap-4 shadow-sm items-center relative overflow-hidden backdrop-blur-sm sm:px-8 sm:py-12">
     <div class="opacity-20 inset-0 absolute">
       <div class="floating-circles">
         <div class="floating-circle" />
@@ -74,27 +74,27 @@ const t = useI18N()
       </div>
     </div>
 
-    <div class="flex flex-col gap-4 items-center relative z-10 w-full min-w-0">
-      <span class="stats-subtitle text-xs sm:text-sm tracking-wide font-medium inline-block text-center px-2">
+    <div class="flex flex-col gap-4 min-w-0 w-full items-center relative z-10">
+      <span class="stats-subtitle text-xs tracking-wide font-medium px-2 text-center inline-block sm:text-sm">
         {{ t.landing.alreadyStatistical }} ({{ t.landing.minutes }})
       </span>
 
       <div
         v-if="status === 'success'"
-        class="stats-number-wrap flex items-end justify-center w-full min-w-0"
+        class="stats-number-wrap flex min-w-0 w-full items-end justify-center"
       >
         <span
           key="b"
-          class="stats-number animate-pulse-glow font-bold font-mono leading-none max-w-full"
+          class="stats-number animate-pulse-glow leading-none font-bold font-mono max-w-full"
         >
           {{ fomater.format(minutes) }}
         </span>
       </div>
 
-      <div v-else class="flex items-end justify-center w-full min-w-0">
+      <div v-else class="flex min-w-0 w-full items-end justify-center">
         <div
           key="a"
-          class="shimmer font-bold font-mono rounded-lg h-12 sm:h-15 w-[min(21rem,80vw)] animate-pulse"
+          class="shimmer font-bold font-mono rounded-lg h-12 w-[min(21rem,80vw)] animate-pulse sm:h-15"
         />
       </div>
 

--- a/app/components/Landing/Title.vue
+++ b/app/components/Landing/Title.vue
@@ -1,18 +1,31 @@
 <template>
-  <div class="lg:text-10xl text-7xl font-bold flex gap-6 md:text-9xl">
+  <div class="landing-title font-bold flex flex-wrap justify-center gap-x-4 gap-y-1 text-center max-w-full min-w-0">
     <span class="gradient-text title-code transition-transform duration-300">Code</span>
     <span class="gradient-text title-time transition-transform duration-300">Time</span>
   </div>
 </template>
 
 <style scoped>
+.landing-title {
+  font-size: clamp(2.4rem, 12vw, 7.5rem);
+  line-height: 0.95;
+}
+
 .gradient-text {
   font-family: "Share Tech Mono", monospace;
+  display: inline-block;
+  max-width: 100%;
   background-clip: text;
   background-size: 500% 500%;
   -webkit-background-clip: text;
   color: transparent;
   animation: spin 12s infinite;
+}
+
+@media (max-width: 380px) {
+  .landing-title {
+    gap: 0.25rem;
+  }
 }
 
 .title-code {

--- a/app/components/Landing/Title.vue
+++ b/app/components/Landing/Title.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="landing-title font-bold flex flex-wrap justify-center gap-x-4 gap-y-1 text-center max-w-full min-w-0">
+  <div class="landing-title font-bold text-center flex flex-wrap gap-x-4 gap-y-1 max-w-full min-w-0 justify-center">
     <span class="gradient-text title-code transition-transform duration-300">Code</span>
     <span class="gradient-text title-time transition-transform duration-300">Time</span>
   </div>

--- a/app/components/LanguageSelect.vue
+++ b/app/components/LanguageSelect.vue
@@ -51,7 +51,7 @@ watchEffect(() => {
   <Select
     v-model="currentLocaleObj"
     aria-label="Language"
-    class="w-[min(11.5rem,calc(100vw-5.5rem))] max-w-full"
+    class="max-w-full w-[min(11.5rem,calc(100vw-5.5rem))]"
     :options="languageOptions"
     @change="onChange"
   />

--- a/app/components/LanguageSelect.vue
+++ b/app/components/LanguageSelect.vue
@@ -51,7 +51,7 @@ watchEffect(() => {
   <Select
     v-model="currentLocaleObj"
     aria-label="Language"
-    class="w-46"
+    class="w-[min(11.5rem,calc(100vw-5.5rem))] max-w-full"
     :options="languageOptions"
     @change="onChange"
   />

--- a/app/layouts/landing.vue
+++ b/app/layouts/landing.vue
@@ -23,9 +23,9 @@ watchEffect(() => {
         alt="Code Time"
         src="/icon.svg"
         width="26"
-        class="ml-1 mr-2 sm:ml-2 sm:mr-3 shrink-0"
+        class="ml-1 mr-2 shrink-0 sm:ml-2 sm:mr-3"
       >
-      <div class="flex gap-2 items-center min-w-0 max-w-full">
+      <div class="flex gap-2 max-w-full min-w-0 items-center">
         <LanguageSelect />
       </div>
     </RHeader>

--- a/app/layouts/landing.vue
+++ b/app/layouts/landing.vue
@@ -18,14 +18,14 @@ watchEffect(() => {
 
 <template>
   <NuxtLayout name="default">
-    <RHeader class="px-4 py-3">
+    <RHeader class="px-3 py-3 sm:px-4">
       <img
         alt="Code Time"
         src="/icon.svg"
         width="26"
-        class="ml-2 mr-3"
+        class="ml-1 mr-2 sm:ml-2 sm:mr-3 shrink-0"
       >
-      <div class="flex gap-2 items-center">
+      <div class="flex gap-2 items-center min-w-0 max-w-full">
         <LanguageSelect />
       </div>
     </RHeader>
@@ -37,5 +37,10 @@ watchEffect(() => {
 <style>
 #__nuxt {
   min-height: 100vh;
+}
+
+html, body {
+  max-width: 100%;
+  overflow-x: clip;
 }
 </style>

--- a/app/pages/[locale]/index.vue
+++ b/app/pages/[locale]/index.vue
@@ -79,25 +79,31 @@ watchEffect(() => {
     <LandingSumHours />
   </div>
 
-  <div class="children:px-2">
-    <div class="m-auto mt-16 p-10 max-w-6xl">
-      <h2 class="text-3xl font-bold my-4 flex flex-col max-w-xl relative md:max-w-6xl">
+  <div class="children:px-2 overflow-x-hidden">
+    <div class="m-auto mt-12 w-full max-w-6xl px-4 py-6 sm:mt-16 sm:p-10">
+      <h2 class="text-2xl font-bold my-4 flex flex-col max-w-xl relative sm:text-3xl md:max-w-6xl">
         {{ t.landing.features.visualization.title }}
       </h2>
-      <div class="text-lg mb-2 mt-4">
+      <div class="text-base mb-2 mt-4 sm:text-lg">
         {{ t.landing.features.visualization.description }}
       </div>
-      <div class="my-8 flex flex-col gap-2">
-        <div class="flex gap-2">
-          <div class="w-86">
+      <div class="my-6 flex flex-col gap-2 sm:my-8">
+        <div class="flex flex-col gap-2 lg:flex-row">
+          <div class="w-full min-w-0 lg:w-86 lg:shrink-0 overflow-x-hidden">
             <DashboardTopCardTemplateDemo />
           </div>
-          <DashboardCalendarCardDemo
-            class="h-234px w-full"
-          />
+          <div class="w-full min-w-0 overflow-x-hidden">
+            <DashboardCalendarCardDemo
+              class="w-full"
+            />
+          </div>
         </div>
-        <DashboardProjectYDotCardDemo />
-        <PoltDailyDistributionTemplateDemo />
+        <div class="min-w-0 overflow-x-auto overscroll-x-contain pb-1">
+          <DashboardProjectYDotCardDemo />
+        </div>
+        <div class="min-w-0 overflow-x-auto overscroll-x-contain pb-1">
+          <PoltDailyDistributionTemplateDemo />
+        </div>
       </div>
     </div>
 

--- a/app/pages/[locale]/index.vue
+++ b/app/pages/[locale]/index.vue
@@ -79,8 +79,8 @@ watchEffect(() => {
     <LandingSumHours />
   </div>
 
-  <div class="children:px-2 overflow-x-hidden">
-    <div class="m-auto mt-12 w-full max-w-6xl px-4 py-6 sm:mt-16 sm:p-10">
+  <div class="overflow-x-hidden children:px-2">
+    <div class="m-auto mt-12 px-4 py-6 max-w-6xl w-full sm:mt-16 sm:p-10">
       <h2 class="text-2xl font-bold my-4 flex flex-col max-w-xl relative sm:text-3xl md:max-w-6xl">
         {{ t.landing.features.visualization.title }}
       </h2>
@@ -89,19 +89,19 @@ watchEffect(() => {
       </div>
       <div class="my-6 flex flex-col gap-2 sm:my-8">
         <div class="flex flex-col gap-2 lg:flex-row">
-          <div class="w-full min-w-0 lg:w-86 lg:shrink-0 overflow-x-hidden">
+          <div class="min-w-0 w-full overflow-x-hidden lg:shrink-0 lg:w-86">
             <DashboardTopCardTemplateDemo />
           </div>
-          <div class="w-full min-w-0 overflow-x-hidden">
+          <div class="min-w-0 w-full overflow-x-hidden">
             <DashboardCalendarCardDemo
               class="w-full"
             />
           </div>
         </div>
-        <div class="min-w-0 overflow-x-auto overscroll-x-contain pb-1">
+        <div class="pb-1 overscroll-x-contain min-w-0 overflow-x-auto">
           <DashboardProjectYDotCardDemo />
         </div>
-        <div class="min-w-0 overflow-x-auto overscroll-x-contain pb-1">
+        <div class="pb-1 overscroll-x-contain min-w-0 overflow-x-auto">
           <PoltDailyDistributionTemplateDemo />
         </div>
       </div>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -51,11 +51,6 @@ export default defineNuxtConfig({
   ], '@sentry/nuxt'],
 
   sitemap: {
-    hostname: 'https://codetime.dev',
-    i18n: {
-      locales: ['en', 'zh-CN'],
-      defaultLocale: 'en',
-    },
     exclude: [
       '/[...slug]',
       '/**/dashboard/**',
@@ -67,7 +62,7 @@ export default defineNuxtConfig({
     },
     autoLastmod: false,
     urls: async () => {
-      // 只为主要页面生成 URL，用户页面通过动态路由处理
+      // Generate URLs only for main pages; user pages are handled by dynamic routes.
       return []
     },
   },

--- a/server/api/__sitemap__/urls.ts
+++ b/server/api/__sitemap__/urls.ts
@@ -1,7 +1,8 @@
+import type { SitemapUrlInput } from '#sitemap/types'
 import { locales } from '~/i18n'
 
 export default defineSitemapEventHandler(async () => {
-  const urls = []
+  const urls: SitemapUrlInput[] = []
 
   // Add homepage for all locales
   for (const locale of locales) {


### PR DESCRIPTION
- Prevent horizontal overflow and black edges on small screens
- Fix header language selector layout on mobile
- Adjust title sizing for better responsiveness
- Resize stats numbers to avoid overflow
- Improve pricing tabs layout on smaller viewports
- Refactor visualization demo layout for responsive behavior
- Fix mobile clipping issue in calendar demo by removing fixed height
- Allow wide plot demos to scroll horizontally within their section instead of expanding page width